### PR TITLE
Remove Activate text

### DIFF
--- a/ascio.php
+++ b/ascio.php
@@ -172,7 +172,6 @@ function ascio_GetNameservers($params) {
 	$values["ns2"] = $ns->NameServer2->HostName;
 	$values["ns3"] = $ns->NameServer3->HostName;
 	$values["ns4"] = $ns->NameServer4->HostName;
-	$values["status"] = "Active";
 
 	return $values;
 }

--- a/ascio.php
+++ b/ascio.php
@@ -172,7 +172,7 @@ function ascio_GetNameservers($params) {
 	$values["ns2"] = $ns->NameServer2->HostName;
 	$values["ns3"] = $ns->NameServer3->HostName;
 	$values["ns4"] = $ns->NameServer4->HostName;
-
+	$values["ns5"] = $ns->NameServer5->HostName;
 	return $values;
 }
 function ascio_SaveNameservers($params) {


### PR DESCRIPTION
```$values["status"] = "Active";```  field does not needed on WHMC. Its bug on WHMCS documentation. 
