### PR TITLE
Manual sync button & Fixed retrieving domain handle for IDN domains

### DIFF
--- a/ascio.php
+++ b/ascio.php
@@ -44,7 +44,8 @@ function ascio_AdminCustomButtonArray() {
     $buttonarray = array(
 	 "Update EPP Code" => "UpdateEPPCode",
 	 "Autorenew On" => "UnexpireDomain",
-	 "Autorenew Off" => "ExpireDomain"
+	 "Autorenew Off" => "ExpireDomain",
+	 "Sync" => "SyncManual"
 	);
 	return $buttonarray;
 }
@@ -395,6 +396,19 @@ function ascio_Sync($params) {
 	$values["expirydate"] = $d->format("Y-m-d");
 	$values["active"] = $request->getDomainStatus($domain);
 	syslog(LOG_INFO, "Syncing ". $params["sld"].".".$params["tld"]);
+	
+	return $values;
+}
+
+function ascio_SyncManual($params) {
+	$request = createRequest($params);
+	$domain = $request->searchDomain($params);
+	$values["message"] = "Syncing " . $params["sld"] . "." . $params["tld"]. " : " . $domain->Status . "\n";
+	if(!$domain) return array("error" => "Domain ".$params["sld"].".".$params["tld"]." not found.");
+	$d = new DateTime($domain->ExpDate);
+	$values["expirydate"] = $d->format("Y-m-d");
+	$values["active"] = $request->getDomainStatus($domain);
+	syslog(LOG_INFO, "Syncing (manual) ". $params["sld"].".".$params["tld"]);
 	
 	return $values;
 }

--- a/lib/Request.php
+++ b/lib/Request.php
@@ -161,21 +161,21 @@ Class Request {
 		$domain = DomainCache::get($domainId);
 		if(isset($domain)) return $domain; 		
 		$handle = $this->getHandle("domain",$domainId,$this->domainName);
-		if($handle) {	
+		if($handle) {
 			$domain =   $this->getDomain($handle);	
 			$domain->domainId = $domainId;
 			$this->setDomainStatus($domain);			
 			DomainCache::put($domain);
 			$this->setHandle($domain);
 			return $domain;	
-		}	
+		}
 		$criteria= array(
 			'Mode' => 'Strict',
 			'Withoutstates' => Array('string' => 'deleted'),
 			'Clauses' => Array(
 				'Clause' => Array(
 					'Attribute' => 'DomainName', 
-					'Value' => $this->domainName , 
+					'Value' => $this->params['domain_punycode'] , 
 					'Operator' => 'Is'
 				)
 			)
@@ -186,7 +186,7 @@ Class Request {
 		);
 		$result =  $this->request("SearchDomain",$ascioParams);
 		if($result->error) return $result;
-		else {						
+		else {
 			$result->domains->Domain->domainId = $domainId;
 			$this->setDomainStatus($result->domains->Domain);
 			DomainCache::put($result->domains->Domain);


### PR DESCRIPTION
With manual sync button you can force manual syncing the domain (not dependant on cron).

Also fixed retrieving domain handle for IDN domains. Api needs it in punycode format it seems, so it failes with domainName if domain is IDN not using punycode-format.