### PR TITLE
Fix stale Ascio handle: no store on failed orders, overwrite on completed

### DIFF
--- a/lib/Request.php
+++ b/lib/Request.php
@@ -323,6 +323,17 @@ Class Request {
 	}
 
 	/**
+	 * Create the SOAP client for a request.
+	 *
+	 * Isolated in its own method so tests can override it (subclass) and inject
+	 * a mock client, exercising the full callback/order lifecycle without a
+	 * network call. Production behaviour is unchanged.
+	 */
+	protected function makeSoapClient($wsdl) {
+		return new \SoapClient($wsdl, array("cache_wsdl" => WSDL_CACHE_MEMORY, "trace" => 1));
+	}
+
+	/**
 	 * Send SOAP request to Ascio v3 API
 	 * v3 uses SOAP headers for authentication instead of session-based auth
 	 */
@@ -334,7 +345,7 @@ Class Request {
 		}
 
 		$wsdl = $this->params["TestMode"]=="on" ? ASCIO_V3_WSDL_TEST : ASCIO_V3_WSDL_LIVE;
-		$client = new \SoapClient($wsdl, array("cache_wsdl" => WSDL_CACHE_MEMORY, "trace" => 1));
+		$client = $this->makeSoapClient($wsdl);
 		$credentials = ["Account" => $this->account, "Password" => $this->password];
 		$header = new \SoapHeader("http://www.ascio.com/2013/02", "SecurityHeaderDetails", $credentials, false);
 		$client->__setSoapHeaders($header);
@@ -980,7 +991,10 @@ Class Request {
 				$this->setDomainStatus($domain);
 				$domain->domainId = $domainId;
 				DomainCache::put($domain);
-				$this->setHandle($domain);
+				// NOTE: the persistent handle is deliberately NOT stored here.
+				// This block runs for every callback, including Failed/Invalid
+				// orders, whose handle must not overwrite the good one. The
+				// handle is persisted only on Completed (see below).
 			}
 		}
 
@@ -1637,12 +1651,19 @@ Class Request {
 					"domain" => $domain
 				]);
 		} else {
+			// Overwrite by (type, whmcs_id, domain) — the same keys getHandle
+			// matched on. Keying the UPDATE on ascio_id would target the NEW
+			// handle, which does not yet exist, silently updating zero rows and
+			// leaving a stale handle behind (e.g. a completed transfer's new
+			// registry handle never replacing the old one).
 			Capsule::table('tblasciohandles')
-				->where('ascio_id', $ascioId)
-				->update([
-					"whmcs_id" => $whmcsId,
+				->where([
 					"type" => $type,
+					"whmcs_id" => $whmcsId,
 					"domain" => $domain
+				])
+				->update([
+					"ascio_id" => $ascioId
 				]);
 		}
 	}

--- a/lib/Tools.php
+++ b/lib/Tools.php
@@ -292,11 +292,12 @@ class Tools {
 		global $cachedAdminUser; 
 		if($cachedAdminUser) return $cachedAdminUser;
 		$result = Capsule::select("select username,notes from tbladmins");
+		$admin = null;
 		foreach ($result as $key => $user) {
 			if($user->notes=="apiuser") return $user->username;
 			$admin = $user->username;
-		}	
-		$cachedAdminUser = $admin; 
+		}
+		$cachedAdminUser = $admin;
 		return $admin;
 	}
 	public static function reformatPrices($result) {

--- a/tests/Mocks/SoapClientMock.php
+++ b/tests/Mocks/SoapClientMock.php
@@ -101,9 +101,39 @@ class SoapClientMock extends \SoapClient
     }
 
     /**
+     * No-op header setter (production sendRequest sets SOAP auth headers).
+     */
+    public function __setSoapHeaders($headers = null): bool
+    {
+        return true;
+    }
+
+    /**
+     * Override __soapCall — this is what Request::sendRequest actually invokes.
+     * Routes to the same response resolution as __call.
+     */
+    public function __soapCall(
+        string $name,
+        array $args,
+        ?array $options = null,
+        $inputHeaders = null,
+        &$outputHeaders = null
+    ): mixed {
+        return $this->resolveResponse($name, $args);
+    }
+
+    /**
      * Override __call to return mock responses
      */
     public function __call(string $functionName, array $arguments): mixed
+    {
+        return $this->resolveResponse($functionName, $arguments);
+    }
+
+    /**
+     * Resolve a canned/default response for a SOAP method call.
+     */
+    private function resolveResponse(string $functionName, array $arguments): mixed
     {
         // Store the request
         self::$lastRequests[$functionName] = $arguments;
@@ -436,5 +466,42 @@ class SoapClientMock extends \SoapClient
                 ]
             ]
         ];
+    }
+}
+
+/**
+ * Object-shaped SOAP payload that also tolerates the module's array-style error
+ * probing (`isset($result['error'])`). Successful Ascio v3 responses are
+ * consumed with `->property` access, while errors are returned by sendRequest as
+ * `['error' => ...]` arrays; this fixture supports both without fataling.
+ */
+#[\AllowDynamicProperties]
+class SoapResponseMock implements \ArrayAccess
+{
+    public function __construct(array $properties = [])
+    {
+        foreach ($properties as $key => $value) {
+            $this->$key = $value;
+        }
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return isset($this->$offset);
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->$offset ?? null;
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->$offset = $value;
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->$offset);
     }
 }

--- a/tests/Unit/HandleLifecycleTest.php
+++ b/tests/Unit/HandleLifecycleTest.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace Ascio\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+use ascio\Request;
+use Ascio\Tests\Mocks\WhmcsFunctionsMock;
+use Ascio\Tests\Mocks\CapsuleMock;
+use Ascio\Tests\Mocks\SoapClientMock;
+use Ascio\Tests\Mocks\SoapResponseMock;
+use Ascio\Tests\Mocks\MockParamsV3;
+
+/**
+ * Full callback-lifecycle tests for the persistent Ascio handle cache
+ * (tblasciohandles), driven end-to-end through Request::getCallbackData with a
+ * mocked SOAP transport.
+ *
+ * Regression target — miserve.info (whmcs_id 227474):
+ *   1. Apr: Transfer FAILED, order carried handle MISERVEI63560.
+ *   2. Jun: Transfer COMPLETED, new registry handle MISERVEI31291.
+ * The completed handle never replaced the stale one, so GetDomain-by-handle kept
+ * returning the dead MISERVEI63560. Two defects:
+ *   D1 — a failed/invalid callback must never persist a handle.
+ *   D2 — a completed callback must overwrite an existing (changed) handle.
+ *
+ * @covers \ascio\Request
+ */
+class HandleLifecycleTest extends TestCase
+{
+    private const DOMAIN = 'miserve.info';
+    private const WHMCS_ID = 227474;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        WhmcsFunctionsMock::reset();
+        CapsuleMock::reset();
+        SoapClientMock::reset();
+
+        // The domain must resolve as an Ascio-registered WHMCS domain.
+        CapsuleMock::setTableData('tbldomains', [
+            [
+                'id' => self::WHMCS_ID,
+                'domain' => self::DOMAIN,
+                'registrar' => 'ascio',
+                'status' => 'Pending',
+            ],
+        ]);
+        CapsuleMock::setTableData('tblasciohandles', []);
+    }
+
+    /**
+     * Build a Request whose SOAP transport is the in-memory mock, and prime the
+     * three calls getCallbackData makes: GetQueueMessage, GetOrder, GetDomain.
+     */
+    private function makeRequest(string $orderType, string $orderStatus, ?string $handle): Request
+    {
+        $params = array_merge(MockParamsV3::getDefault(), [
+            'domainname' => self::DOMAIN,
+            'TestMode' => 'on',
+        ]);
+
+        $request = new class($params) extends Request {
+            protected function makeSoapClient($wsdl) {
+                return new SoapClientMock();
+            }
+        };
+
+        // sendRequest returns $response->{Method}Result, and the module then
+        // probes that value with isset($x['error']); so the inner Result object
+        // must be array-tolerant (SoapResponseMock).
+
+        // GetQueueMessage -> GetQueueMessageResult
+        SoapClientMock::setResponse('GetQueueMessage', (object) [
+            'GetQueueMessageResult' => new SoapResponseMock([
+                'ResultCode' => 200,
+                'DomainName' => self::DOMAIN,
+                'ObjectName' => self::DOMAIN,
+                'StatusList' => (object) ['CallbackStatus' => []],
+            ]),
+        ]);
+
+        // GetOrder -> GetOrderResult. TransactionComment carries the WHMCS
+        // domainId, exactly like a real WHMCS-initiated order.
+        $orderDomain = (object) ['DomainName' => self::DOMAIN];
+        if ($handle !== null) {
+            $orderDomain->DomainHandle = $handle;
+        }
+        SoapClientMock::setResponse('GetOrder', (object) [
+            'GetOrderResult' => new SoapResponseMock([
+                'ResultCode' => 200,
+                'Order' => (object) [
+                    'Type' => $orderType,
+                    'Status' => $orderStatus,
+                    'Domain' => $orderDomain,
+                    'TransactionComment' => json_encode([
+                        'application' => 'WHMCS',
+                        'domainId' => self::WHMCS_ID,
+                        'objectType' => 'Domain',
+                    ]),
+                ],
+            ]),
+        ]);
+
+        // GetDomain(handle) -> GetDomainResult.Domain, echoing that same handle.
+        // getCallbackData array-probes the returned domain too, so it is also
+        // array-tolerant.
+        if ($handle !== null) {
+            SoapClientMock::setResponse('GetDomain', (object) [
+                'GetDomainResult' => (object) [
+                    'ResultCode' => 200,
+                    'Domain' => new SoapResponseMock([
+                        'DomainName' => self::DOMAIN,
+                        'DomainHandle' => $handle,
+                        'Status' => 'ACTIVE',
+                    ]),
+                ],
+            ]);
+        }
+
+        // AckQueueMessage -> generic 200.
+        SoapClientMock::setResponse('AckQueueMessage', (object) [
+            'AckQueueMessageResult' => new SoapResponseMock(['ResultCode' => 200]),
+        ]);
+
+        return $request;
+    }
+
+    private function storedHandle(Request $request): ?string
+    {
+        return $request->getHandle('domain', self::WHMCS_ID, self::DOMAIN);
+    }
+
+    // =========================================================================
+    // D1 — failed / invalid callbacks must not persist a handle
+    // =========================================================================
+
+    #[Test]
+    public function failedTransferCallbackDoesNotStoreHandle(): void
+    {
+        $request = $this->makeRequest('Transfer', 'Failed', 'MISERVEI63560');
+
+        $request->getCallbackData('Failed', 'MSG-1', 'A100624334', 'Poll-Message');
+
+        $this->assertNull(
+            $this->storedHandle($request),
+            'A failed transfer must not persist its handle into tblasciohandles'
+        );
+    }
+
+    #[Test]
+    public function invalidTransferCallbackDoesNotStoreHandle(): void
+    {
+        // Invalid order in the wild carried no handle at all (see screenshot).
+        $request = $this->makeRequest('Transfer', 'Invalid', null);
+
+        $request->getCallbackData('Invalid', 'MSG-2', 'A101712949', 'Poll-Message');
+
+        $this->assertNull(
+            $this->storedHandle($request),
+            'An invalid transfer must not persist a handle'
+        );
+    }
+
+    // =========================================================================
+    // D2 — completed callbacks persist / overwrite the handle
+    // =========================================================================
+
+    #[Test]
+    public function completedTransferStoresHandle(): void
+    {
+        $request = $this->makeRequest('Transfer', 'Completed', 'MISERVEI31291');
+
+        $request->getCallbackData('Completed', 'MSG-3', 'A101588707', 'Poll-Message');
+
+        $this->assertEquals(
+            'MISERVEI31291',
+            $this->storedHandle($request),
+            'A completed transfer must persist its registry handle'
+        );
+    }
+
+    /**
+     * The exact miserve.info sequence: a failed transfer runs first, then the
+     * successful one. The final stored handle must be the completed order's.
+     */
+    #[Test]
+    public function completedTransferOverwritesStaleFailedHandle(): void
+    {
+        // Stale handle from the earlier failed transfer already in the cache.
+        CapsuleMock::setTableData('tblasciohandles', [
+            [
+                'type' => 'domain',
+                'whmcs_id' => self::WHMCS_ID,
+                'domain' => self::DOMAIN,
+                'ascio_id' => 'MISERVEI63560',
+            ],
+        ]);
+
+        $request = $this->makeRequest('Transfer', 'Completed', 'MISERVEI31291');
+
+        $request->getCallbackData('Completed', 'MSG-4', 'A101588707', 'Poll-Message');
+
+        $this->assertEquals(
+            'MISERVEI31291',
+            $this->storedHandle($request),
+            'A completed transfer must overwrite the stale failed-transfer handle'
+        );
+    }
+}

--- a/tests/Unit/RequestTest.php
+++ b/tests/Unit/RequestTest.php
@@ -530,6 +530,40 @@ class RequestTest extends TestCase
         $this->assertEquals('tblasciohandles', $query['table']);
     }
 
+    /**
+     * Regression: a completed transfer produces a NEW registry handle for the
+     * same (whmcs_id, domain). storeHandle must overwrite the stale handle.
+     *
+     * Reproduces miserve.info: stale handle MISERVEI63560 was never replaced by
+     * the completed-transfer handle MISERVEI31291, because the UPDATE branch
+     * keyed on the (new, not-yet-existing) ascio_id and matched zero rows.
+     */
+    #[Test]
+    public function testStoreHandleOverwritesChangedHandleForSameDomain(): void
+    {
+        CapsuleMock::setTableData('tblasciohandles', [
+            [
+                'type' => 'domain',
+                'whmcs_id' => 227474,
+                'domain' => 'miserve.info',
+                'ascio_id' => 'MISERVEI63560', // stale handle from failed transfer
+            ],
+        ]);
+
+        $request = new Request($this->defaultParams);
+
+        // Completed transfer resync with the new registry handle.
+        $request->storeHandle('domain', 227474, 'MISERVEI31291', 'miserve.info');
+
+        $stored = $request->getHandle('domain', 227474, 'miserve.info');
+
+        $this->assertEquals(
+            'MISERVEI31291',
+            $stored,
+            'storeHandle must overwrite a changed handle for the same (whmcs_id, domain)'
+        );
+    }
+
     // =========================================================================
     // Simulation Mode Tests
     // =========================================================================


### PR DESCRIPTION
## Problem

A domain's `tblasciohandles` entry could keep a **stale registry handle** from a failed transfer instead of the handle from the later successful one.

Observed on **miserve.info** (whmcs_id 227474):
- Apr: Transfer **Failed**, order carried handle `MISERVEI63560`.
- Jun: Transfer **Completed**, new registry handle `MISERVEI31291`.
- GetDomain-by-handle kept returning the dead `MISERVEI63560`; the completed handle never replaced it.

## Root cause — two defects

**D1 — handle persisted for non-completed orders.**
`getCallbackData` stored the handle in the "get full domain info" block, which runs for **every** callback (Failed/Invalid included), *before* the `orderStatus === "Completed"` check. A failed transfer carrying a handle created/overwrote the persistent entry.
Fix: handle is persisted only in the Completed branch.

**D2 — completed order could not overwrite a changed handle.**
`storeHandle`'s UPDATE keyed on `WHERE ascio_id = <new handle>` — a value not yet in the table — so it matched **zero rows** and silently left the stale handle. `deleteOldHandle`+insert masked this only on the Completed path; `searchDomain` resyncs hit the dead UPDATE branch and no-op'd.
Fix: UPDATE now keys on `(type, whmcs_id, domain)` — the same keys `getHandle` matched on.

## Also
- Extracted `makeSoapClient()` as a test-injection seam (no production behavior change).
- `Tools::getApiUser` — initialise `$admin` to `null` (kills an undefined-variable warning).

## Not changed (by design)
- Details-page lookup keeps GetDomain-by-handle with SearchDomain fallback, so deleted/expired/transferred-away domains stay visible with live nameservers.
- SOAP `isset($x['error'])` checks left as-is — works in prod, never failed.

## Tested functions

| Test | What it proves |
|------|----------------|
| `RequestTest::testStoreHandleOverwritesChangedHandleForSameDomain` | D2: a changed handle for the same (whmcs_id, domain) is overwritten |
| `HandleLifecycleTest::failedTransferCallbackDoesNotStoreHandle` | D1: Failed callback persists no handle |
| `HandleLifecycleTest::invalidTransferCallbackDoesNotStoreHandle` | D1: Invalid callback persists no handle |
| `HandleLifecycleTest::completedTransferStoresHandle` | Completed callback persists the registry handle |
| `HandleLifecycleTest::completedTransferOverwritesStaleFailedHandle` | The exact miserve.info Failed-then-Completed sequence resolves to `MISERVEI31291` |

Full lifecycle tests drive `getCallbackData` end-to-end through a mocked SOAP transport (no network). Both regressions were verified genuinely **red** without the fixes.

Unit suite: **1063 tests pass, 0 failures, 0 warnings.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)