### PR TITLE
Fix stale Ascio handle (master): no store on failed orders, overwrite on completed

### DIFF
--- a/lib/Request.php
+++ b/lib/Request.php
@@ -267,12 +267,15 @@ Class Request {
 			Tools::log("DomainId: " . $domainId." not found in the WHMCS-Database: " .$order->order->Type. ", Domain: ".$domainName.", Order-Status: ".$orderStatus. ", MessageId" . $messageId . "\n ");
 			return;	
 		}
-		if($order->order->Domain->DomaiHandle) {
+		if($order->order->Domain->DomainHandle) {
 			$domain = $this->getDomain($order->order->Domain->DomainHandle);
 			$this->setDomainStatus($domain);
 			$domain->domainId = $domainId;
 			DomainCache::put($domain);
-			$this->setHandle($domain);
+			// The persistent handle is deliberately NOT stored here. This block
+			// runs for every callback, including Failed/Invalid orders, whose
+			// handle must not overwrite the good one. The handle is persisted
+			// only on Completed (see below).
 		}
 		$this->params["domainname"] = $domainName;
 		$msgPart = "Domain (". $domainId . "): ".$domainName;
@@ -954,14 +957,20 @@ Class Request {
 					"whmcs_id" => $whmcsId,
 					"type" => $type,
 					"domain" => $domain]);		
-		} else {			
+		} else {
+			// Overwrite by (type, whmcs_id, domain) — the same keys getHandle
+			// matched on. Keying the UPDATE on ascio_id would target the NEW
+			// handle, which does not yet exist, silently updating zero rows and
+			// leaving a stale handle behind (e.g. a completed transfer's new
+			// registry handle never replacing the old one).
 			Capsule::table('tblasciohandles')
-				->where('ascio_id',$ascioId)
-				->update([
-					"whmcs_id" => $whmcsId,
+				->where([
 					"type" => $type,
-					"domain" => $domain]);			
-		}		
+					"whmcs_id" => $whmcsId,
+					"domain" => $domain])
+				->update([
+					"ascio_id" => $ascioId]);
+		}
 	}
 	public function deleteOldHandles($domainName) {
 		foreach($this->getHandlesByDomain($domainName) as $key => $ascioId)  {

--- a/lib/Tools.php
+++ b/lib/Tools.php
@@ -260,11 +260,12 @@ class Tools {
 		global $cachedAdminUser; 
 		if($cachedAdminUser) return $cachedAdminUser;
 		$result = Capsule::select("select username,notes from tbladmins");
+		$admin = null;
 		foreach ($result as $key => $user) {
 			if($user->notes=="apiuser") return $user->username;
 			$admin = $user->username;
-		}	
-		$cachedAdminUser = $admin; 
+		}
+		$cachedAdminUser = $admin;
 		return $admin;
 	}
 	public static function reformatPrices($result) {


### PR DESCRIPTION
Ports the handle-cache fixes from beta/v2 (#34) to `master`, adapted to master's code shape. Manual port — a cherry-pick could not apply (divergent code, no shared test infra).

## Problem

A domain's `tblasciohandles` entry could keep a **stale registry handle** from a failed transfer instead of the handle from the later successful one (observed on miserve.info: kept `MISERVEI63560` from a failed transfer instead of `MISERVEI31291` from the completed one).

## Fixes

**D1 — handle persisted for non-completed orders.**
`getCallbackData` stored the handle before the `orderStatus == "Completed"` check, so a Failed/Invalid transfer carrying a handle could persist it. Now stored only in the Completed branch.
Also fixes a latent typo `Domain->DomaiHandle` → `DomainHandle` that left the domain-lookup block dead, so the Completed store ran with a `null` domain and never persisted anything.

**D2 — completed order could not overwrite a changed handle.**
`storeHandle`'s UPDATE keyed on `WHERE ascio_id = <new handle>` — a value not yet in the table — so it matched zero rows and silently kept the stale handle. UPDATE now keys on `(type, whmcs_id, domain)`.

**Also:** `Tools::getApiUser` initialises `$admin` to `null` (undefined-variable warning).

## Testing

`master` has no phpunit suite (test infra lives on beta/v2), so no automated tests are included here. Both edited files pass `php -l`. The equivalent fix on beta/v2 is covered by unit + full-lifecycle tests (#34), verified genuinely red without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)